### PR TITLE
ci: GHA→ghcr builds for chrome-service-novnc, android-emulator, infra CLI (ADR-0002)

### DIFF
--- a/.github/workflows/build-android-emulator.yml
+++ b/.github/workflows/build-android-emulator.yml
@@ -1,0 +1,36 @@
+name: Build android-emulator
+
+# ADR-0002: infra-owned image built off-infra on GHA → ghcr (public).
+# Large image (Android SDK + emulator); on-demand workload (scaled 0). Rebuilds
+# rare → dispatch + path trigger.
+on:
+  push:
+    branches: [master]
+    paths:
+      - 'stacks/android-emulator/docker/**'
+  workflow_dispatch: {}
+
+permissions:
+  contents: read
+  packages: write
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: docker/setup-buildx-action@v3
+      - uses: docker/login-action@v3
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+      - uses: docker/build-push-action@v6
+        with:
+          context: stacks/android-emulator/docker
+          platforms: linux/amd64
+          provenance: false
+          push: true
+          tags: |
+            ghcr.io/viktorbarzin/android-emulator:latest
+            ghcr.io/viktorbarzin/android-emulator:${{ github.sha }}

--- a/.github/workflows/build-chrome-service-novnc.yml
+++ b/.github/workflows/build-chrome-service-novnc.yml
@@ -1,0 +1,36 @@
+name: Build chrome-service-novnc
+
+# ADR-0002: infra-owned image built off-infra on GHA → ghcr (public).
+# Source Dockerfile identical on both git remotes, so the github checkout builds
+# the current image. Rebuilds are rare (stable noVNC proxy) → dispatch + path.
+on:
+  push:
+    branches: [master]
+    paths:
+      - 'stacks/chrome-service/files/novnc/**'
+  workflow_dispatch: {}
+
+permissions:
+  contents: read
+  packages: write
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: docker/setup-buildx-action@v3
+      - uses: docker/login-action@v3
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+      - uses: docker/build-push-action@v6
+        with:
+          context: stacks/chrome-service/files/novnc
+          platforms: linux/amd64
+          provenance: false
+          push: true
+          tags: |
+            ghcr.io/viktorbarzin/chrome-service-novnc:latest
+            ghcr.io/viktorbarzin/chrome-service-novnc:${{ github.sha }}

--- a/.github/workflows/build-cli.yml
+++ b/.github/workflows/build-cli.yml
@@ -1,0 +1,41 @@
+name: Build infra CLI
+
+# ADR-0002: infra CLI built off-infra on GHA. Replaces the Woodpecker
+# build-cli.yml. Pushes to DockerHub (public distribution, kept) + ghcr.
+# Not a cluster workload — a distributed tool image.
+on:
+  push:
+    branches: [master]
+    paths:
+      - 'cli/**'
+  workflow_dispatch: {}
+
+permissions:
+  contents: read
+  packages: write
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: docker/setup-buildx-action@v3
+      - uses: docker/login-action@v3
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+      - uses: docker/login-action@v3
+        with:
+          username: ${{ secrets.DOCKERHUB_USERNAME }}
+          password: ${{ secrets.DOCKERHUB_TOKEN }}
+      - uses: docker/build-push-action@v6
+        with:
+          context: cli
+          platforms: linux/amd64
+          provenance: false
+          push: true
+          tags: |
+            viktorbarzin/infra:latest
+            ghcr.io/viktorbarzin/infra-cli:latest
+            ghcr.io/viktorbarzin/infra-cli:${{ github.sha }}


### PR DESCRIPTION
Adds 3 GHA build workflows (ADR-0002 #29/#30). Canonical change on forgejo master 1621f0b2; this lands the workflows on the github lineage so GHA runs them. No history reconcile — 3 new files only.