### PR TITLE
fix(k8s-portal): npm install so GHA builds

### DIFF
--- a/stacks/k8s-portal/modules/k8s-portal/files/Dockerfile
+++ b/stacks/k8s-portal/modules/k8s-portal/files/Dockerfile
@@ -1,7 +1,7 @@
 FROM node:22-alpine AS build
 WORKDIR /app
 COPY package*.json ./
-RUN npm ci
+RUN npm install --no-audit --no-fund
 COPY . .
 RUN npm run build
 


### PR DESCRIPTION
package-lock.json never committed; npm ci needs it. npm install unblocks the GHA build.